### PR TITLE
Library fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ As I first used a SDP610 and a library I found on github I adhered the style fro
 
 ## Compatibility
 This library is compatible with the following sensors:
-- SDP3x series: SDP31, SDP36, SDP37
+- SDP3x series: SDP31, SDP32, SDP36, SDP37
 - SDP8xx series: SDP800, SDP810, SDP806, SDP816
 
 To use it with the SDP800 series, please keep in mind that the I2C address

--- a/README.md
+++ b/README.md
@@ -7,3 +7,20 @@ I try to sort it out and add all the funcitonality of the sensor as well as writ
 Short documentation can be found on http://rac.su/libs/sensirion-sdp3x-driver
 
 As I first used a SDP610 and a library I found on github I adhered the style from the SDP6x library from Antony Burness, but replaced the code with the sample code from Sensirion for the SDP3x
+
+## Compatibility
+This library is compatible with the following sensors:
+- SDP3x series: SDP31, SDP36, SDP37
+- SDP8xx series: SDP800, SDP810, SDP806, SDP816
+
+To use it with the SDP800 series, please keep in mind that the I2C address
+needs to be adjusted. To do that, add the following line to your `init()`
+function:
+
+```c++
+SDP3x.setI2CAddress(DEFAULT_SDP8XX_I2C_ADDRESS);
+```
+
+Note that while both the 500Pa and 125Pa version should work, the library has
+only been tested with the 500PA version so far. Feedback on the 125Pa version
+is appreciated!

--- a/SDP3x.cpp
+++ b/SDP3x.cpp
@@ -56,11 +56,14 @@ float SDP3xClass::getTemperature(void)
 uint8_t SDP3xClass::readSensor(uint8_t* readData, uint8_t size)
 {
   uint8_t rxByteCount=0;
-  uint8_t txData[2] = {SDP_MEASUREMENT_COMMAND_0, SDP_MEASUREMENT_COMMAND_1};
+
+  uint8_t txData[COMMAND_DATA_LENGTH] =
+    {SDP_MEASUREMENT_COMMAND_0, SDP_MEASUREMENT_COMMAND_1};
 
   Wire.beginTransmission(SDP3x_I2C_ADDRESS);
-  Wire.write(txData, sizeof(txData));
+  Wire.write(txData, COMMAND_DATA_LENGTH);
   Wire.endTransmission();
+
   // wait for data conversion in sensor
   delay(50);
 

--- a/SDP3x.cpp
+++ b/SDP3x.cpp
@@ -25,12 +25,12 @@ float SDP3xClass::getPressureDiff(void)
 }
 
 /**********************************************************
- * getTemparature
- *  Gets the current Temparature from the sensor.
+ * getTemperature
+ *  Gets the current Temperature from the sensor.
  *
- * @return float - The Temparature
+ * @return float - The Temperature
  **********************************************************/
-float SDP3xClass::getTemparature(void)
+float SDP3xClass::getTemperature(void)
 {
   int16_t  temperature_ticks;
   // merge chars to one int

--- a/SDP3x.cpp
+++ b/SDP3x.cpp
@@ -17,8 +17,11 @@
 float SDP3xClass::getPressureDiff(void)
 {
   int16_t dp_ticks;
+  uint8_t readData[RESULT_DATA_LENGTH] = { 0 };
+
+  readSensor(readData, RESULT_DATA_LENGTH);
   // merge chars to one int
-  dp_ticks = BIU16(readSensor(), 0);
+  dp_ticks = BIU16(readData, 0);
   // adapt scale factor according to datasheet (here for version SDP31)
   float dp_scale = 60.0;
   return dp_ticks/dp_scale;
@@ -33,8 +36,11 @@ float SDP3xClass::getPressureDiff(void)
 float SDP3xClass::getTemperature(void)
 {
   int16_t  temperature_ticks;
+  uint8_t readData[RESULT_DATA_LENGTH] = { 0 };
+
+  readSensor(readData, RESULT_DATA_LENGTH);
   // merge chars to one int
-  temperature_ticks = BIU16(readSensor(), 3);
+  temperature_ticks = BIU16(readData, 3);
   float t_scale = 200.0;
   return temperature_ticks/t_scale;
 }
@@ -43,11 +49,12 @@ float SDP3xClass::getTemperature(void)
  * readSensor
  *  Gets RAW sensor data
  *
- * @return uint8_t - RAW sensor data
+ * @param readData - a data buffer to store data into
+ * @param size     - the size of said data buffer
+ * @return uint8_t - number of bytes read
  ******************************************************************************/
-uint8_t SDP3xClass::readSensor(void)
+uint8_t SDP3xClass::readSensor(uint8_t* readData, uint8_t size)
 {
-  uint8_t readData[6];
   uint8_t rxByteCount=0;
   
   // triggered mode with 50ms conversion time
@@ -63,13 +70,13 @@ uint8_t SDP3xClass::readSensor(void)
   delay(50);
 
   // 2 bytes DP, 1 CRC, 2 bytes T, 1 CRC
-  Wire.requestFrom(SDP3x_I2C_ADDRESS, (uint8_t)6);
+  Wire.requestFrom(SDP3x_I2C_ADDRESS, (uint8_t)size);
   rxByteCount = 0;
   while (Wire.available()) { // wait till all arrive
       readData[rxByteCount] = Wire.read();
       rxByteCount++;
   }
-  return readData;    
+  return rxByteCount;
 }
 
 SDP3xClass SDP3x;

--- a/SDP3x.cpp
+++ b/SDP3x.cpp
@@ -56,11 +56,6 @@ float SDP3xClass::getTemperature(void)
 uint8_t SDP3xClass::readSensor(uint8_t* readData, uint8_t size)
 {
   uint8_t rxByteCount=0;
-  
-  // triggered mode with 50ms conversion time
-  const uint8_t SDP_MEASUREMENT_COMMAND_0 = 0x36;
-  const uint8_t SDP_MEASUREMENT_COMMAND_1 = 0x2F;
-  
   uint8_t txData[2] = {SDP_MEASUREMENT_COMMAND_0, SDP_MEASUREMENT_COMMAND_1};
 
   Wire.beginTransmission(SDP3x_I2C_ADDRESS);

--- a/SDP3x.cpp
+++ b/SDP3x.cpp
@@ -70,7 +70,7 @@ uint8_t SDP3xClass::readSensor(uint8_t* readData, uint8_t size)
   delay(50);
 
   // 2 bytes DP, 1 CRC, 2 bytes T, 1 CRC
-  Wire.requestFrom(SDP3x_I2C_ADDRESS, (uint8_t)size);
+  Wire.requestFrom((uint8_t)SDP3x_I2C_ADDRESS, size);
   rxByteCount = 0;
   while (Wire.available()) { // wait till all arrive
       readData[rxByteCount] = Wire.read();

--- a/SDP3x.cpp
+++ b/SDP3x.cpp
@@ -17,14 +17,15 @@
 float SDP3xClass::getPressureDiff(void)
 {
   int16_t dp_ticks;
+  int16_t dp_scale;
   uint8_t readData[RESULT_DATA_LENGTH] = { 0 };
 
   readSensor(readData, RESULT_DATA_LENGTH);
   // merge chars to one int
   dp_ticks = BIU16(readData, 0);
-  // adapt scale factor according to datasheet (here for version SDP31)
-  float dp_scale = 60.0;
-  return dp_ticks/dp_scale;
+  dp_scale = BIU16(readData, 6);
+
+  return dp_ticks/(float)dp_scale;
 }
 
 /**********************************************************

--- a/SDP3x.cpp
+++ b/SDP3x.cpp
@@ -19,6 +19,18 @@
  * Global Functions
  ******************************************************************************/
 
+
+ /******************************************************************************
+  * setI2CAddress
+  *  Changes I2C address
+  *
+  * @param i2cAddress - the I2C address to use
+  ******************************************************************************/
+ void SDP3xClass::setI2CAddress(uint8_t i2cAddress)
+ {
+   mI2CAddress = i2cAddress;
+ }
+
 /**********************************************************
  * getPressureDiff
  *  Gets the current Pressure Differential from the sensor.
@@ -72,7 +84,7 @@ uint8_t SDP3xClass::readSensor(uint8_t* readData, uint8_t size)
   uint8_t txData[COMMAND_DATA_LENGTH] =
     {SDP_MEASUREMENT_COMMAND_0, SDP_MEASUREMENT_COMMAND_1};
 
-  Wire.beginTransmission(SDP3x_I2C_ADDRESS);
+  Wire.beginTransmission(mI2CAddress);
   Wire.write(txData, COMMAND_DATA_LENGTH);
   Wire.endTransmission();
 
@@ -80,7 +92,7 @@ uint8_t SDP3xClass::readSensor(uint8_t* readData, uint8_t size)
   delay(50);
 
   // 2 bytes DP, 1 CRC, 2 bytes T, 1 CRC
-  Wire.requestFrom((uint8_t)SDP3x_I2C_ADDRESS, size);
+  Wire.requestFrom((uint8_t)mI2CAddress, size);
   rxByteCount = 0;
   while (Wire.available()) { // wait till all arrive
       readData[rxByteCount] = Wire.read();

--- a/SDP3x.cpp
+++ b/SDP3x.cpp
@@ -4,6 +4,17 @@
 #include "Arduino.h"
 #include "SDP3x.h"
 
+#define SDP_DEBUG
+
+#ifdef SDP_DEBUG
+#define DEBUG_PRINT(label, value) \
+  Serial.print(" ["); \
+  Serial.print(label); Serial.print(" = "); Serial.print(value); \
+  Serial.print("] ");
+
+#else
+#define DEBUG_PRINT(label, value)
+#endif
 /******************************************************************************
  * Global Functions
  ******************************************************************************/

--- a/SDP3x.h
+++ b/SDP3x.h
@@ -24,9 +24,7 @@
 	{
 	  public:
 	  	uint8_t readSensor(uint8_t* readData, uint8_t size);
-	  public:
 	  	float getPressureDiff(void);
-	  public:
 	  	float getTemperature(void);
 	};
 

--- a/SDP3x.h
+++ b/SDP3x.h
@@ -13,6 +13,7 @@
 		#define SDP3x_I2C_ADDRESS 0x21
 	#endif
 
+	// triggered mode with 50ms conversion time
 	typedef enum {
 	   SDP_MEASUREMENT_COMMAND_0 = 0x36,
 	   SDP_MEASUREMENT_COMMAND_1 = 0x2F

--- a/SDP3x.h
+++ b/SDP3x.h
@@ -4,6 +4,9 @@
 	// convert two 8 bit values to one word
 	#define BIU16(data, start) (((uint16_t)(data)[start]) << 8 | ((data)[start + 1]))
 
+	// data length of result from I2C
+	#define RESULT_DATA_LENGTH 6
+
 	// SDP3x sensor I2C address
 	// The adress can be overwritten by defining SDP3x_I2C_ADDRESS in your sketch directly
 	#ifndef SDP3x_I2C_ADDRESS
@@ -18,7 +21,7 @@
 	class SDP3xClass
 	{
 	  public:
-	  	uint8_t readSensor(void);
+	  	uint8_t readSensor(uint8_t* readData, uint8_t size);
 	  public:
 	  	float getPressureDiff(void);
 	  public:

--- a/SDP3x.h
+++ b/SDP3x.h
@@ -18,7 +18,7 @@
 	class SDP3xClass
 	{
 	  public:
-	  	int16_t readSensor(void);
+	  	uint8_t readSensor(void);
 	  public:
 	  	float getPressureDiff(void);
 	  public:

--- a/SDP3x.h
+++ b/SDP3x.h
@@ -8,11 +8,8 @@
 	#define COMMAND_DATA_LENGTH 2
 	#define RESULT_DATA_LENGTH 6
 
-	// SDP3x sensor I2C address
-	// The adress can be overwritten by defining SDP3x_I2C_ADDRESS in your sketch directly
-	#ifndef SDP3x_I2C_ADDRESS
-		#define SDP3x_I2C_ADDRESS 0x21
-	#endif
+	#define DEFAULT_SDP3X_I2C_ADDRESS  0x21
+	#define DEFAULT_SDP8XX_I2C_ADDRESS 0x25
 
 	// triggered mode with 50ms conversion time
 	typedef enum {
@@ -23,9 +20,15 @@
 	class SDP3xClass
 	{
 	  public:
+	  	SDP3xClass() : mI2CAddress(DEFAULT_SDP3X_I2C_ADDRESS) {}
+	  	void setI2CAddress(uint8_t i2cAddress);
+
 	  	uint8_t readSensor(uint8_t* readData, uint8_t size);
 	  	float getPressureDiff(void);
 	  	float getTemperature(void);
+
+	  private:
+	  	uint8_t mI2CAddress;
 	};
 
 	extern SDP3xClass SDP3x;

--- a/SDP3x.h
+++ b/SDP3x.h
@@ -5,6 +5,7 @@
 	#define BIU16(data, start) (((uint16_t)(data)[start]) << 8 | ((data)[start + 1]))
 
 	// data length of result from I2C
+	#define COMMAND_DATA_LENGTH 2
 	#define RESULT_DATA_LENGTH 6
 
 	// SDP3x sensor I2C address

--- a/examples/SDP3x_simplest/SDP3x_simplest.ino
+++ b/examples/SDP3x_simplest/SDP3x_simplest.ino
@@ -9,7 +9,7 @@ void setup() {
 	// Initialize I2C communication
 	Wire.begin();
 
-	// To set a different I2C address, uncomment the define
+	// To set a different I2C address, uncomment the line below
 	// SDP3x.setI2CAddress(0x25);
 }
 

--- a/examples/SDP3x_simplest/SDP3x_simplest.ino
+++ b/examples/SDP3x_simplest/SDP3x_simplest.ino
@@ -1,7 +1,5 @@
 #include <Wire.h>
 
-// To set a different I2C address, uncomment the define
-// #define SDP3x_I2C_ADDRESS 0x21
 #include "SDP3x.h"
 
 // Setup routine runs once when you press reset
@@ -10,6 +8,9 @@ void setup() {
 	Serial.begin(9600);
 	// Initialize I2C communication
 	Wire.begin();
+
+	// To set a different I2C address, uncomment the define
+	// SDP3x.setI2CAddress(0x25);
 }
 
 // the loop routine runs over and over again forever


### PR DESCRIPTION
A few changes based on test reports we've gotten:
1) change readSensor() to take a data buffer as input to make sure we're not accessing temporary memory
2) read scale factor from I2C, to enable 125 Pa sensor (untested)
3) added a method call to allow changing the I2C address, rather then using defines
4) added note about supported sensors, as well as changing I2C addresses, to the README
5) Fixed typos, compiler warnings

Let me know if you have any questions/change requests!